### PR TITLE
Reporting: Expose CRC queue methods for other uses.

### DIFF
--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -87,6 +87,13 @@ namespace Reporting
 	// Get the latest compatibility result.  Only valid when GetStatus() is not BUSY.
 	std::vector<std::string> CompatibilitySuggestions();
 
+	// Queues game for CRC hash if needed, and returns true if the hash is available.
+	bool HasCRC(const std::string &gamePath);
+
+	// Blocks until the CRC hash is available for game, and returns it.
+	// To avoid stalling, call HasCRC() in update() or similar and call this if it returns true.
+	uint32_t RetrieveCRC(const std::string &gamePath);
+
 	// Returns true if that identifier has not been logged yet.
 	bool ShouldLogNTimes(const char *identifier, int n);
 


### PR DESCRIPTION
This way UI can expose the CRC if needed.